### PR TITLE
potential addition for accomodating users without javascript

### DIFF
--- a/dalek.rs/index.html
+++ b/dalek.rs/index.html
@@ -44,6 +44,12 @@
     <link rel="apple-touch-icon-precomposed" href="assets/ico/apple-touch-icon-57-precomposed.png">
     <link rel="shortcut icon" href="assets/ico/favicon.png">
 
+    <noscript>
+      <style>
+        body { visibility: visible }
+      </style>
+    </noscript>
+
   </head>
 
   <body data-spy="scroll" data-target=".navbar" data-offset="0px">


### PR DESCRIPTION
Just the snippet from kristopolous to make BOOTSTRA.386 pages visible for users without javascript.
Allows interaction with most of the page except the dropdown features and the live modal of the mailing list message which just do not react.